### PR TITLE
Require the latest cryoforge

### DIFF
--- a/requirements-static.txt
+++ b/requirements-static.txt
@@ -1,4 +1,4 @@
 ruff==0.12.0
 mypy==1.16.1
-cryoforge>=0.2.3
+cryoforge>=0.3.0
 -e .


### PR DESCRIPTION
Fixes a formatting issue with the velocity dataset version number

https://github.com/betolink/cryoforge/releases/tag/v0.3.0